### PR TITLE
fix: JS Event in wishlist-extension is not being catched

### DIFF
--- a/src/Resources/app/storefront/src/main.js
+++ b/src/Resources/app/storefront/src/main.js
@@ -18,5 +18,5 @@ if (window.sasShowOnOffCanvasCart) {
 }
 
 if (window.sasShowOnWishlistPage) {
-    PluginManager.register('SasWishlistExtension', WishlistExtensionPlugin, '.wishlist-page');
+    PluginManager.register('SasWishlistExtension', WishlistExtensionPlugin, '[data-wishlist-storage]');
 }

--- a/src/Resources/app/storefront/src/plugin/wishlist-extension.plugin.js
+++ b/src/Resources/app/storefront/src/plugin/wishlist-extension.plugin.js
@@ -6,7 +6,7 @@ export default class WishlistExtensionPlugin extends Plugin {
         plugin.$emitter.subscribe(
             'Wishlist/onProductRemoved',
             () => {
-                console.log('Product removed from wishlist with window.PluginManager.getPlugin');
+               
                 window.location.reload();
             }
         );

--- a/src/Resources/app/storefront/src/plugin/wishlist-extension.plugin.js
+++ b/src/Resources/app/storefront/src/plugin/wishlist-extension.plugin.js
@@ -6,7 +6,6 @@ export default class WishlistExtensionPlugin extends Plugin {
         plugin.$emitter.subscribe(
             'Wishlist/onProductRemoved',
             () => {
-               
                 window.location.reload();
             }
         );

--- a/src/Resources/app/storefront/src/plugin/wishlist-extension.plugin.js
+++ b/src/Resources/app/storefront/src/plugin/wishlist-extension.plugin.js
@@ -2,9 +2,11 @@ import Plugin from 'src/plugin-system/plugin.class';
 
 export default class WishlistExtensionPlugin extends Plugin {
     init() {
-        this.$emitter.subscribe(
+        const plugin = window.PluginManager.getPluginInstanceFromElement(document.querySelector('[data-wishlist-storage]'), 'WishlistStorage');
+        plugin.$emitter.subscribe(
             'Wishlist/onProductRemoved',
             () => {
+                console.log('Product removed from wishlist with window.PluginManager.getPlugin');
                 window.location.reload();
             }
         );


### PR DESCRIPTION
Since Shopwar JS events are only available in the plugin-emitter that they are thrown in

Related: MOSHOP-191