### PR TITLE
WIP: Allow Variant-Switch in Product Slider

### DIFF
--- a/src/Decorator/ProductSliderElementResolverDecorator.php
+++ b/src/Decorator/ProductSliderElementResolverDecorator.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SasVariantSwitch\Decorator;
+
+use SasVariantSwitch\Storefront\Page\ProductListingConfigurationLoader;
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
+use Shopware\Core\Content\Cms\DataResolver\CriteriaCollection;
+use Shopware\Core\Content\Cms\DataResolver\Element\AbstractCmsElementResolver;
+use Shopware\Core\Content\Cms\DataResolver\Element\CmsElementResolverInterface;
+use Shopware\Core\Content\Cms\DataResolver\Element\ElementDataCollection;
+use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
+use Shopware\Core\Content\Product\Cms\ProductSliderCmsElementResolver;
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireDecorated;
+
+#[AsDecorator(decorates: ProductSliderCmsElementResolver::class)]
+class ProductSliderElementResolverDecorator extends AbstractCmsElementResolver
+{
+    public function __construct(
+        #[AutowireDecorated]
+        private readonly CmsElementResolverInterface $inner,
+        private readonly ProductListingConfigurationLoader $listingConfigurationLoader,
+    ) {
+
+    }
+
+
+    public function getType(): string
+    {
+        return $this->inner->getType();
+    }
+
+    public function collect(CmsSlotEntity $slot, ResolverContext $resolverContext): ?CriteriaCollection
+    {
+        return $this->inner->collect($slot, $resolverContext);
+    }
+
+    public function enrich(CmsSlotEntity $slot, ResolverContext $resolverContext, ElementDataCollection $result): void
+    {
+        $this->inner->enrich($slot, $resolverContext, $result);
+
+        $data = $slot->getData();
+
+        $products = $data?->getProducts();
+        if (!$products) {
+            return;
+        }
+
+        $context = $resolverContext->getSalesChannelContext();
+
+        //FIXME enrich Product since it is missing $product->getConfiguratorSettings()  and $product->getParentId()
+
+        $this->listingConfigurationLoader->loadListing($products, $context);
+
+        $data->setProducts($products);
+        $slot->setData($data);
+    }
+}
+


### PR DESCRIPTION
Related: MOSHOP-275


Der PR ist WORK IN PROGRESS.

$this->listingConfigurationLoader->loadListing($products, $context); wird übersprungen, weil dem Produkt die im FIXME genannten Informationen fehlen. Diese müssen hinzugefügt werden.